### PR TITLE
Fix Android PanResponder Bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ export default class extends Component {
                             onMomentumScrollEnd={this._onMomentumScrollEnd}
                             onFocusCapture={this._onFocus} {...otherProps}>
                     <Animated.View style={{ marginBottom: this._contentBottomOffset }}
-                                   onStartShouldSetResponderCapture={this._onStartShouldSetResponderCapture}>
+                                   onMoveShouldSetPanResponderCapture={this._onMoveShouldSetPanResponderCapture}>
                         {children}
                     </Animated.View>
                 </ScrollView>
@@ -154,7 +154,7 @@ export default class extends Component {
     };
 
     // 这个方法是为了防止 ScrollView 在滑动结束后触发 TextInput 的 focus 事件
-    _onStartShouldSetResponderCapture = ({...event}) => {
+    _onMoveShouldSetPanResponderCapture = ({...event}) => {
         if (event.target === TextInputState.currentlyFocusedField()) return false;
 
         let uiViewClassName;


### PR DESCRIPTION
Issue: 

PanResponder onStartShouldSetPanResponderCapture is preventing text input on Android. The issue is not present on iOS. 

Proposed solution: 

Change onStartShouldSetPanResponderCapture to onMoveShouldSetPanResponderCapture, text input on Android is working while retaining the scroll-to functionality.

Video:

![onstart_vs_onmove](https://user-images.githubusercontent.com/12532803/31292383-0e84798c-aa88-11e7-959b-ee63aabda336.gif)

Versions:

React Native 0.48.4
React 16.0.0-alpha.12