### PR TITLE
Fixing issue mentioned on #15

### DIFF
--- a/index.js
+++ b/index.js
@@ -306,7 +306,29 @@ export default class extends Component {
 
     _scrollToKeyboard = (target, offset) => {
         const toKeyboardOffset = this._topOffset + this.props.keyboardOffset - offset;
-        this._root.scrollResponderScrollNativeHandleToKeyboard(target, toKeyboardOffset, true);
+        
+        const scrollResponder = this._getScrollResponder();
+
+        if (!target || !scrollResponder) {
+            return;
+        };
+
+        UIManager.viewIsDescendantOf(
+            target,
+            scrollResponder.getInnerViewNode(),
+            (isAncestor) => {
+                if (isAncestor) {
+                    this._root.scrollResponderScrollNativeHandleToKeyboard(target, toKeyboardOffset, true);
+                };
+            }
+        );
+    };
+
+    _getScrollResponder = () => {
+        return (
+            this._root &&
+            this._root.getScrollResponder()
+        );
     };
 
     _onKeyboardShow = () => {

--- a/index.js
+++ b/index.js
@@ -14,9 +14,9 @@ import {
     KeyboardAvoidingView,
     Keyboard,
     Platform,
-    Animated
+    Animated,
+    UIManager
 } from 'react-native';
-import TextInputState from 'react-native/Libraries/Components/TextInput/TextInputState';
 
 const isIOS = Platform.OS === 'ios';
 
@@ -280,7 +280,7 @@ export default class extends Component {
     _scrollToKeyboardRequest = () => {
         if (!this._keyboardShow) return;
 
-        const curFocusTarget = TextInputState.currentlyFocusedField();
+        const curFocusTarget = TextInput.State.currentlyFocusedField();
         if (!curFocusTarget) return;
 
         const { text, selectionEnd, width, height } = this._getInputInfo(curFocusTarget);
@@ -306,7 +306,7 @@ export default class extends Component {
 
     _scrollToKeyboard = (target, offset) => {
         const toKeyboardOffset = this._topOffset + this.props.keyboardOffset - offset;
-        
+
         const scrollResponder = this._getScrollResponder();
 
         if (!target || !scrollResponder) {
@@ -351,7 +351,7 @@ export default class extends Component {
     // 这个方法是为了防止 ScrollView 在滑动结束后触发 TextInput 的 focus 事件
     _onTouchStart = ({ ...event }) => {
         const target = event.target || event.currentTarget;
-        if (target === TextInputState.currentlyFocusedField()) return false;
+        if (target === TextInput.State.currentlyFocusedField()) return false;
 
         const targetInst = event._targetInst;
         let uiViewClassName;
@@ -368,12 +368,12 @@ export default class extends Component {
     _onFocus = ({ ...event }) => {
         // 当 onStartShouldSetResponderCapture 返回 true 时
         // 被激活的 TextInput 无法使用 Keyboard.dismiss() 来收起键盘
-        // TextInputState.currentlyFocusedField() 也无法获取当前焦点ID
+        // TextInput.State.currentlyFocusedField() 也无法获取当前焦点ID
         // 原因可能是系统并未判定 TextInput 获取焦点，这可能是一个 bug
         // 通常需要在 onStartShouldSetResponderCapture 返回 false 的情况下再点击一次 TextInput 才能恢复正常
         // 所以这里手动再设置一次焦点
         const target = event.target || event.currentTarget;
-        TextInputState.focusTextInput(target);
+        TextInput.State.focusTextInput(target);
 
         const inputInfo = this._getInputInfo(target);
         const multiline = getProps(event._targetInst).multiline;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-input-scroll-view",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "Perfect TextInput ScrollView",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
@baijunjie @luco 

So about the issue #15 

- Screens stack on each other, meaning the previous screen is still mounted, so module did not call the `_removeListener` function because previous screen never got unmounted.
- When the screen that's being pushed on the stack is mounted, module registers another set of keyboard listeners.
- When you focus a input on the new screen the module calls both listeners (on previous and current screen).
-  That causes conflict because listener on previous screen is being called searching for an input that has been focused and is located on current screen causing the app to crash.

A solution to the problem is a simple check if a focused input is a descendant of a ScrollView. Meaning it will try to scroll to an input only if it finds it.

Checked it both on Android and on iOS and it works like a charm. 
I also replaced a direct link to `TextInputState` with `TextInput.State` and bumped up the version code.

@baijunjie  You could update the README, I think this will resolve all the problems for now.