### PR TITLE
Adding scroll on focus for any TextInput

### DIFF
--- a/index.js
+++ b/index.js
@@ -181,7 +181,7 @@ export default class extends Component {
             newComponent.props = { ...Component.props };
             newComponent.props.children = this._cloneDeepComponents(Component.props.children);
             return newComponent;
-        } else if (Component && Component.props && Component.props.multiline) {
+        } else if (Component && Component.type === TextInput) {
             const newComponent = { ...Component };
             newComponent.props = { ...Component.props };
             return this._addMultilineHandle(newComponent);


### PR DESCRIPTION
Currently, we are unable to make it works if the component doesn't have a 'multiline' property, so even if we focus on a TextInput, the scroll wouldn't work

The code was checking explicity to the multiline property, now I changed it to check for TextInput