### PR TITLE
If text equals undefined -> check the default value

### DIFF
--- a/index.js
+++ b/index.js
@@ -366,9 +366,11 @@ export default class extends Component {
         const multiline = getProps(event._targetInst).multiline;
 
         if (multiline) {
-            if (inputInfo.text === undefined) {
-                inputInfo.text = getProps(event._targetInst).value;
-            }
+          if (inputInfo.text === undefined) {
+              inputInfo.text = getProps(event._targetInst).value;
+          }else if(getProps(event._targetInst).defaultValue !== undefined){
+              inputINfo.text = getProps(event._targetInst).defaultValue;
+          }
 
             if (!isIOS) return;
 


### PR DESCRIPTION
Check the default value if the text is undefined, because it could be that a default value is set and if this is not noticed, the cursor could be on the wrong place. 