### PR TITLE
Check defaultValue - use measure for less undefined height or widths - remove default fontSize 

### DIFF
--- a/index.js
+++ b/index.js
@@ -290,25 +290,28 @@ export default class extends Component {
             (isAncestor) => {
                 if (!isAncestor) return;
 
-                const { text, selectionEnd, width, height } = this._getInputInfo(curFocusTarget);
-                const cursorAtLastLine = !text ||
-                    selectionEnd === undefined ||
-                    text.length === selectionEnd;
+                UIManager.measure(curFocusTarget, (originX, originY, width, height, pageX, pageY) => {
+                  const { text, selectionEnd} = this._getInputInfo(curFocusTarget);
+                  const cursorAtLastLine = !text ||
+                      selectionEnd === undefined ||
+                      text.length === selectionEnd;
 
-                if (cursorAtLastLine) {
-                    return this._scrollToKeyboard(curFocusTarget, 0);
-                }
+                  if (cursorAtLastLine) {
+                      return this._scrollToKeyboard(curFocusTarget, 0);
+                  }
 
-                this._measureCursorPosition(
-                    text.substr(0, selectionEnd),
-                    width,
-                    cursorRelativeTopOffset => {
-                        this._scrollToKeyboard(
-                            curFocusTarget,
-                            Math.max(0, height - cursorRelativeTopOffset)
-                        );
-                    }
-                );
+                  this._measureCursorPosition(
+                      text.substr(0, selectionEnd),
+                      width,
+                      cursorRelativeTopOffset => {
+                          this._scrollToKeyboard(
+                              curFocusTarget,
+                              Math.max(0, height - cursorRelativeTopOffset)
+                          );
+                      }
+                  );
+                })
+
             }
         );
     };

--- a/index.js
+++ b/index.js
@@ -73,7 +73,9 @@ export default class extends Component {
 
     static defaultProps = {
         keyboardOffset: 40,
-        multilineInputStyle: { fontSize: 17 },
+        multilineInputStyle: {
+          //fontSize: 17
+        },
         useAnimatedScrollView: false,
     };
 

--- a/index.js
+++ b/index.js
@@ -367,7 +367,11 @@ export default class extends Component {
 
         if (multiline) {
             if (inputInfo.text === undefined) {
-                inputInfo.text = getProps(event._targetInst).value;
+                if(getProps(event._targetInst).value !== undefined){
+                  inputInfo.text = getProps(event._targetInst).value;
+                }else if(getProps(event._targetInst).defaultValue !== undefined){
+                    inputInfo.text = getProps(event._targetInst).defaultValue;
+                }
             }
 
             if (!isIOS) return;


### PR DESCRIPTION
**Check defaultValue**
If the multiline input text box has a default value, it is not recognized by the plugin as text as the plugin only checks the text property.  Added proposal to also check the defaultValue. 

**Use measure for less undefined height or widths**
When calculating the height/ width, the plugin uses the property value of height and width, it would be better to calculate it with the measure function. 

**Remove default fontSize**
Why do you put a default fontSize of 17 in de styles? If the user does not provide a style, it will use font size 17 for calculating cursor height, resulting in a bad calculation. Put it in comment line to show the user he could add specific styling used for the calculation. 