### PR TITLE
Removing comma after after rest element

### DIFF
--- a/index.js
+++ b/index.js
@@ -105,7 +105,7 @@ export default class extends Component {
             multilineInputStyle,
             children,
             useAnimatedScrollView,
-            ...otherProps,
+            ...otherProps
         } = this.props;
 
         const {


### PR DESCRIPTION
Breaks for me using Babel.

Is also not allowed in the spec, so worth removing regardless of my issue.
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Trailing_commas#Illegal_trailing_commas