### PR TITLE
Events: used persist instead of clone

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,6 @@ import {
     Animated,
     UIManager,
 } from 'react-native';
-import cloneDeep from 'lodash/cloneDeep';
 
 const isIOS = Platform.OS === 'ios';
 
@@ -36,10 +35,10 @@ if (isIOS) {
             }
         };
         return function(event) {
-            const e = cloneDeep(event);
+            event.persist();
             cancelAnimationFrame(id);
             count = wait;
-            action.call(this, e);
+            action.call(this, event);
         };
     };
 } else {
@@ -55,10 +54,10 @@ if (isIOS) {
             }
         };
         return function(event) {
-            const e = cloneDeep(event);
+            event.persist();
             clearTimeout(id);
             count = wait;
-            action.call(this, e);
+            action.call(this, event);
         };
     };
 }
@@ -207,13 +206,13 @@ export default class extends PureComponent {
         };
 
         Component.props.onSelectionChange = event => {
-            const e = cloneDeep(event);
+            event.persist();
             if (isIOS) {
                 // 确保处理代码在 onChange 之后执行
                 // release 版本必须使用 requestAnimationFrame
-                requestAnimationFrame(() => this._onSelectionChange(e));
+                requestAnimationFrame(() => this._onSelectionChange(event));
             } else {
-                setTimeout(() => this._onSelectionChange(e));
+                setTimeout(() => this._onSelectionChange(event));
             }
             onSelectionChange &&
             onSelectionChange(event);

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   },
   "homepage": "https://github.com/baijunjie/react-native-input-scroll-view#readme",
   "dependencies": {
-    "lodash": "^4.17.10",
     "prop-types": "^15.5.10"
   },
   "files": [


### PR DESCRIPTION
I experienced the same issue than [46](https://github.com/baijunjie/react-native-input-scroll-view/issues/46) and fixed it with this.

I understand that you clone the events because the SyntheticEvent is pooled and the properties are set to `null`. [React gives a way to persist the events](https://reactjs.org/docs/events.html#event-pooling) so we can get rid of `cloneDeep` and its heavy memory cost and the lodash dependency 🍾 !