### PR TITLE
"padding" behavior removed from KeyboardAvoidingView component for IOS

### DIFF
--- a/index.js
+++ b/index.js
@@ -115,8 +115,6 @@ export default class extends PureComponent {
             ...otherProps
         } = this.props;
 
-        const kavProps = Object.assign({ behavior: isIOS ? 'padding' : null }, keyboardAvoidingViewProps);
-
         const {
             measureInputVisible,
             measureInputValue,
@@ -128,7 +126,7 @@ export default class extends PureComponent {
         const ScrollComponent = useAnimatedScrollView ? Animated.ScrollView : ScrollView;
 
         return (
-            <KeyboardAvoidingView {...kavProps}>
+            <KeyboardAvoidingView {...keyboardAvoidingViewProps}>
                 <View style={styles.wrap}>
                     <ScrollComponent ref={this._onRef}
                                      onFocus={this._onFocus}


### PR DESCRIPTION
Hello! I am Greg from Russia, Kazan. 
We had the following bug in our project. This twitching is shown in the gif.

![Mar-29-2019 11-51-31](https://user-images.githubusercontent.com/44202486/55220881-51b53180-5219-11e9-846a-14c0cd698bc5.gif)

It was caused by "behavior" property set to "padding" in KeyboardAvoidingView component.
So I've removed this property in your project, cause it is not the proper place for customization like that.
Kind regards.

